### PR TITLE
reduced frequency of events and new objects

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,38 +1,47 @@
-var createGame = require('voxel-engine')
-var texturePath = require('painterly-textures')(__dirname)
-var highlight = require('./')
+var createGame = require('voxel-engine');
+var texturePath = require('painterly-textures')(__dirname);
+var highlighter = require('./');
 
-var container = document.querySelector('#container')
+var container = document.querySelector('#container');
 
 var game = createGame({
   startingPosition: [0, 1000, 0],
   texturePath: texturePath
-})
+});
 
+game.controls.pitchObject.rotation.x = -1.5; // look down
+game.appendTo(container);
+game.currentMaterial = 1;
 
-window.game = game // for debugging
-game.controls.pitchObject.rotation.x = -1.5 // look down
-game.appendTo(container)
-game.currentMaterial = 1
+var highlight = highlighter(game, {
+  distance: 100,
+  wireframeLinewidth: 10,
+});
 
-highlight(game)
+highlight.on('highlight', function(position, mesh, vidx) {
+  console.log('highlighted: ' + vidx);
+});
+
+highlight.on('remove', function(mesh, vidx) {
+  console.log('# UN-highlighted ' + vidx);
+});
 
 game.on('mousedown', function (pos) {
-  if (game.erase) game.setBlock(pos, 0)
-  else game.createBlock(pos, game.currentMaterial)
-})
+  if (game.erase) game.setBlock(pos, 0);
+  else game.createBlock(pos, game.currentMaterial);
+});
 
 container.addEventListener('click', function() {
-  game.requestPointerLock(container)
-})
+  game.requestPointerLock(container);
+});
 
-game.erase = true
+game.erase = true;
 window.addEventListener('keydown', function (ev) {
   if (ev.keyCode === 'X'.charCodeAt(0)) {
-    game.erase = !game.erase
+    game.erase = !game.erase;
   }
-})
+});
 
 function ctrlToggle (ev) { game.erase = !ev.ctrlKey }
-window.addEventListener('keyup', ctrlToggle)
-window.addEventListener('keydown', ctrlToggle)
+window.addEventListener('keyup', ctrlToggle);
+window.addEventListener('keydown', ctrlToggle);

--- a/demo.js
+++ b/demo.js
@@ -1,47 +1,47 @@
-var createGame = require('voxel-engine');
-var texturePath = require('painterly-textures')(__dirname);
-var highlighter = require('./');
+var createGame = require('voxel-engine')
+var texturePath = require('painterly-textures')(__dirname)
+var highlighter = require('./')
 
-var container = document.querySelector('#container');
+var container = document.querySelector('#container')
 
 var game = createGame({
   startingPosition: [0, 1000, 0],
   texturePath: texturePath
-});
+})
 
-game.controls.pitchObject.rotation.x = -1.5; // look down
-game.appendTo(container);
-game.currentMaterial = 1;
+game.controls.pitchObject.rotation.x = -1.5 // look down
+game.appendTo(container)
+game.currentMaterial = 1
 
 var highlight = highlighter(game, {
   distance: 100,
   wireframeLinewidth: 10,
-});
+})
 
 highlight.on('highlight', function(position, mesh, vidx) {
-  console.log('highlighted: ' + vidx);
-});
+  console.log('highlighted voxel: ' + vidx)
+})
 
 highlight.on('remove', function(mesh, vidx) {
-  console.log('# UN-highlighted ' + vidx);
-});
+  console.log('UN-highlighted voxel: ' + vidx)
+})
 
 game.on('mousedown', function (pos) {
-  if (game.erase) game.setBlock(pos, 0);
-  else game.createBlock(pos, game.currentMaterial);
-});
+  if (game.erase) game.setBlock(pos, 0)
+  else game.createBlock(pos, game.currentMaterial)
+})
 
 container.addEventListener('click', function() {
-  game.requestPointerLock(container);
-});
+  game.requestPointerLock(container)
+})
 
-game.erase = true;
+game.erase = true
 window.addEventListener('keydown', function (ev) {
   if (ev.keyCode === 'X'.charCodeAt(0)) {
-    game.erase = !game.erase;
+    game.erase = !game.erase
   }
-});
+})
 
 function ctrlToggle (ev) { game.erase = !ev.ctrlKey }
-window.addEventListener('keyup', ctrlToggle);
-window.addEventListener('keydown', ctrlToggle);
+window.addEventListener('keyup', ctrlToggle)
+window.addEventListener('keydown', ctrlToggle)

--- a/index.js
+++ b/index.js
@@ -1,51 +1,75 @@
-var inherits = require('inherits')
-var events = require('events')
-var _ = require('underscore')
+var inherits = require('inherits');
+var events = require('events');
+var _ = require('underscore');
 
-module.exports = function(game, opts) {
-  return new Highlighter(game, opts)
-}
+module.exports = function (game, opts) {
+  return new Highlighter(game, opts);
+};
 
 function Highlighter(game, opts) {
-  if (!opts) opts = {}
-  this.opts = opts
-  this.game = game
-  this.game.on('tick', _.throttle(this.highlight.bind(this), this.opts.frequency || 100))
-}
-
-inherits(Highlighter, events.EventEmitter)
-
-Highlighter.prototype.highlight = function() {
-  if (this.highlight) {
-    this.game.scene.remove(this.highlight)
-    this.emit('remove', this.highlight)
-  }
-  var hit = this.game.raycast(this.opts.distance || 500)
-  if (!hit) return
-  var voxelVector = this.game.voxels.voxelVector(hit)
-  var chunk = this.game.voxels.chunkAtPosition(hit)
-  var pos = this.game.voxels.getBounds(chunk[0], chunk[1], chunk[2])[0]
-  var size = game.cubeSize
-  pos[0] = pos[0] * size
-  pos[1] = pos[1] * size
-  pos[2] = pos[2] * size
-  pos[0] += voxelVector.x * size
-  pos[1] += voxelVector.y * size
-  pos[2] += voxelVector.z * size
-  pos = new game.THREE.Vector3(pos[0] + size / 2, pos[1] + size / 2, pos[2] + size / 2)
-  var geometry = this.opts.geometry || new game.THREE.CubeGeometry( size + 0.01, size + 0.01, size + 0.01 )
-  var material = this.opts.material || new game.THREE.MeshBasicMaterial({
-    color: 0x000000,
+  this.opts = opts || {};
+  this.game = game;
+  this.prevVoxelIdx = 0;
+  this.cameraPosition = new this.game.THREE.Vector3();
+  this.cameraVector = new this.game.THREE.Vector3();
+  var size = this.game.cubeSize;
+  var geometry = this.opts.geometry || new this.game.THREE.CubeGeometry(size + 0.01, size + 0.01, size + 0.01);
+  var material = this.opts.material || new this.game.THREE.MeshBasicMaterial({
+    color: new this.game.THREE.Color(0x000000),
     wireframe: true,
-    wireframeLinewidth: this.opts.wireframeLinewidth || 3,
-    transparent: true,
-    opacity: this.opts.wireframeOpacity || 0.5
-  })
-  var cube = new game.THREE.Mesh(geometry, material)
-  cube.position.copy(pos)
-  this.highlight = cube
-  this.game.scene.add(cube)
-  this.emit('highlight', pos, cube)
+    wireframeLinewidth: this.opts.wireframeLinewidth || 3
+  });
+  this.cube = new this.game.THREE.Mesh(geometry, material);
+  this.highlightActive = false;
+  this.game.on('tick', _.throttle(this.highlight.bind(this), this.opts.frequency || 100));
 }
 
+inherits(Highlighter, events.EventEmitter);
 
+Highlighter.prototype.highlight = function () {
+  var self = this;
+  var removeHighlight = function () {
+    self.game.scene.remove(self.cube);
+    self.emit('remove', self.cube, self.prevVoxelIdx);
+    self.highlightActive = false;
+  };
+  var getCameraPosition = function () { // only for legacy voxel-engine 0.3.6 support
+    self.cameraPosition.multiplyScalar(0);
+    self.game.camera.matrixWorld.multiplyVector3(self.cameraPosition);
+    return self.cameraPosition;
+  };
+  var getCameraVector = function () { // only for legacy voxel-engine 0.3.6 support
+    self.cameraVector.multiplyScalar(0);
+    self.cameraVector.z = -1;
+    self.game.camera.matrixWorld.multiplyVector3(self.cameraVector);
+    self.cameraVector.subSelf(self.cameraPosition).normalize();
+    return self.cameraVector;
+  };
+  var camPos = (this.game.cameraPosition && this.game.cameraPosition()) || getCameraPosition();
+  var camVec = (this.game.cameraVector && this.game.cameraVector()) || getCameraVector();
+  var hit = this.game.raycast(camPos, camVec, this.opts.distance || 500);
+  if (!hit) {
+    if (this.highlightActive) removeHighlight();
+    return;
+  }
+  var voxelVector = this.game.voxels.voxelVector(hit);
+  var voxelIdx = this.game.voxels.voxelIndex(voxelVector);
+  if (this.highlightActive) {
+    if (this.prevVoxelIdx === voxelIdx) return; // no change
+    removeHighlight();
+  }
+  this.prevVoxelIdx = voxelIdx;
+  var chunk = this.game.voxels.chunkAtPosition(hit);
+  var pos = this.game.voxels.getBounds(chunk[0], chunk[1], chunk[2])[0];
+  var size = this.game.cubeSize;
+  pos[0] = pos[0] * size;
+  pos[1] = pos[1] * size;
+  pos[2] = pos[2] * size;
+  pos[0] += voxelVector.x * size;
+  pos[1] += voxelVector.y * size;
+  pos[2] += voxelVector.z * size;
+  this.cube.position.set(pos[0] + size / 2, pos[1] + size / 2, pos[2] + size / 2);
+  this.game.scene.add(this.cube);
+  this.highlightActive = true;
+  this.emit('highlight', pos, this.cube, voxelIdx);
+}

--- a/index.js
+++ b/index.js
@@ -1,75 +1,75 @@
-var inherits = require('inherits');
-var events = require('events');
-var _ = require('underscore');
+var inherits = require('inherits')
+var events = require('events')
+var _ = require('underscore')
 
 module.exports = function (game, opts) {
-  return new Highlighter(game, opts);
-};
+  return new Highlighter(game, opts)
+}
 
 function Highlighter(game, opts) {
-  this.opts = opts || {};
-  this.game = game;
-  this.prevVoxelIdx = 0;
-  this.cameraPosition = new this.game.THREE.Vector3();
-  this.cameraVector = new this.game.THREE.Vector3();
-  var size = this.game.cubeSize;
-  var geometry = this.opts.geometry || new this.game.THREE.CubeGeometry(size + 0.01, size + 0.01, size + 0.01);
+  this.opts = opts || {}
+  this.game = game
+  this.prevVoxelIdx = 0
+  this.cameraPosition = new this.game.THREE.Vector3()
+  this.cameraVector = new this.game.THREE.Vector3()
+  var size = this.game.cubeSize
+  var geometry = this.opts.geometry || new this.game.THREE.CubeGeometry(size + 0.01, size + 0.01, size + 0.01)
   var material = this.opts.material || new this.game.THREE.MeshBasicMaterial({
     color: new this.game.THREE.Color(0x000000),
     wireframe: true,
     wireframeLinewidth: this.opts.wireframeLinewidth || 3
-  });
-  this.cube = new this.game.THREE.Mesh(geometry, material);
-  this.highlightActive = false;
-  this.game.on('tick', _.throttle(this.highlight.bind(this), this.opts.frequency || 100));
+  })
+  this.cube = new this.game.THREE.Mesh(geometry, material)
+  this.highlightActive = false
+  this.game.on('tick', _.throttle(this.highlight.bind(this), this.opts.frequency || 100))
 }
 
-inherits(Highlighter, events.EventEmitter);
+inherits(Highlighter, events.EventEmitter)
 
 Highlighter.prototype.highlight = function () {
-  var self = this;
+  var self = this
   var removeHighlight = function () {
-    self.game.scene.remove(self.cube);
-    self.emit('remove', self.cube, self.prevVoxelIdx);
-    self.highlightActive = false;
-  };
+    self.game.scene.remove(self.cube)
+    self.emit('remove', self.cube, self.prevVoxelIdx)
+    self.highlightActive = false
+  }
   var getCameraPosition = function () { // only for legacy voxel-engine 0.3.6 support
-    self.cameraPosition.multiplyScalar(0);
-    self.game.camera.matrixWorld.multiplyVector3(self.cameraPosition);
-    return self.cameraPosition;
-  };
+    self.cameraPosition.multiplyScalar(0)
+    self.game.camera.matrixWorld.multiplyVector3(self.cameraPosition)
+    return self.cameraPosition
+  }
   var getCameraVector = function () { // only for legacy voxel-engine 0.3.6 support
-    self.cameraVector.multiplyScalar(0);
-    self.cameraVector.z = -1;
-    self.game.camera.matrixWorld.multiplyVector3(self.cameraVector);
-    self.cameraVector.subSelf(self.cameraPosition).normalize();
-    return self.cameraVector;
-  };
-  var camPos = (this.game.cameraPosition && this.game.cameraPosition()) || getCameraPosition();
-  var camVec = (this.game.cameraVector && this.game.cameraVector()) || getCameraVector();
-  var hit = this.game.raycast(camPos, camVec, this.opts.distance || 500);
+    self.cameraVector.multiplyScalar(0)
+    self.cameraVector.z = -1
+    self.game.camera.matrixWorld.multiplyVector3(self.cameraVector)
+    self.cameraVector.subSelf(self.cameraPosition).normalize()
+    return self.cameraVector
+  }
+  var camPos = (this.game.cameraPosition && this.game.cameraPosition()) || getCameraPosition()
+  var camVec = (this.game.cameraVector && this.game.cameraVector()) || getCameraVector()
+  var hit = this.game.raycast(camPos, camVec, this.opts.distance || 500)
   if (!hit) {
-    if (this.highlightActive) removeHighlight();
-    return;
+    if (this.highlightActive) removeHighlight()
+    return
   }
-  var voxelVector = this.game.voxels.voxelVector(hit);
-  var voxelIdx = this.game.voxels.voxelIndex(voxelVector);
+  var voxelVector = this.game.voxels.voxelVector(hit)
+  var voxelIdx = this.game.voxels.voxelIndex(voxelVector)
   if (this.highlightActive) {
-    if (this.prevVoxelIdx === voxelIdx) return; // no change
-    removeHighlight();
+    if (this.prevVoxelIdx === voxelIdx) return // no change
+    removeHighlight()
   }
-  this.prevVoxelIdx = voxelIdx;
-  var chunk = this.game.voxels.chunkAtPosition(hit);
-  var pos = this.game.voxels.getBounds(chunk[0], chunk[1], chunk[2])[0];
-  var size = this.game.cubeSize;
-  pos[0] = pos[0] * size;
-  pos[1] = pos[1] * size;
-  pos[2] = pos[2] * size;
-  pos[0] += voxelVector.x * size;
-  pos[1] += voxelVector.y * size;
-  pos[2] += voxelVector.z * size;
-  this.cube.position.set(pos[0] + size / 2, pos[1] + size / 2, pos[2] + size / 2);
-  this.game.scene.add(this.cube);
-  this.highlightActive = true;
-  this.emit('highlight', pos, this.cube, voxelIdx);
+  this.prevVoxelIdx = voxelIdx
+  var chunk = this.game.voxels.chunkAtPosition(hit)
+  var pos = this.game.voxels.getBounds(chunk[0], chunk[1], chunk[2])[0]
+  var size = this.game.cubeSize
+  pos[0] = pos[0] * size
+  pos[1] = pos[1] * size
+  pos[2] = pos[2] * size
+  pos[0] += voxelVector.x * size
+  pos[1] += voxelVector.y * size
+  pos[2] += voxelVector.z * size
+  this.cube.position.set(pos[0] + size / 2, pos[1] + size / 2, pos[2] + size / 2)
+  this.game.scene.add(this.cube)
+  this.highlightActive = true
+  this.emit('highlight', pos, this.cube, voxelIdx)
 }


### PR DESCRIPTION
Hey, I noticed that events were firing 20 times a second so I started poking around. Then I got a little carried away...

I hope it is not too drastic, but I ended up making the following changes:
1. 'remove' event only fired if block is no longer highlighted
2. 'highlight' event only fired if new block is highlighted (or same block is re-highlighted)
3. for both events, the block's voxel index is passed to the callback for reference
4. THREE geometry, material, and mesh objects are only created once (in constructor)
5. Updated camera interrogation to work for both voxel-engine 0.3.6 and 0.5.8
6. Ready for integration into current voxel-hello-world demo project

Thanks for considering it!
