### PR TITLE
loose ends: repo url, docs, demo usage, added back wireframeOpacity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ npm install voxel-highlight
 
 ```javascript
 var highlight = require('voxel-highlight')
-highlight(game)
+var highlighter = highlight(game)
+highlighter.on('highlight', function (position, mesh, voxelIndex) {
+  console.log('highlighted voxel: ' + voxelIndex)
+})
 ```
 
 ### highlight(gameInstance, optionalOptions)
@@ -23,16 +26,16 @@ options can be:
   distance: how far in game distance things should be highlighted, default is 500
   geometry: threejs geometry to use for the highlight, default is a cubegeometry
   material: material to use with the geometry, default is a wireframe
-  wireframeLinewidth: if using default wireframe, default is 3
-  wireframeOpacity: if using default wireframe, default is 0.5
+  wireframeLinewidth: if using default material wireframe, default is 3
+  wireframeOpacity: if using default material wireframe, default is 0.5
 }
 ```
 
-### highlight.on('highlight', function(position, mesh) {})
+### highlight.on('highlight', function(position, mesh, voxelIndex) {})
 
 gets called when highlighter highlights something
 
-### highlight.on('remove', function(mesh) {})
+### highlight.on('remove', function(mesh, voxelIndex) {})
 
 gets called when highlighter unhighlights something. mesh also has a `.position`
 

--- a/demo.js
+++ b/demo.js
@@ -1,6 +1,6 @@
 var createGame = require('voxel-engine')
 var texturePath = require('painterly-textures')(__dirname)
-var highlighter = require('./')
+var highlight = require('./')
 
 var container = document.querySelector('#container')
 
@@ -13,16 +13,16 @@ game.controls.pitchObject.rotation.x = -1.5 // look down
 game.appendTo(container)
 game.currentMaterial = 1
 
-var highlight = highlighter(game, {
+var highlighter = highlight(game, {
   distance: 100,
   wireframeLinewidth: 10,
 })
 
-highlight.on('highlight', function(position, mesh, vidx) {
+highlighter.on('highlight', function(position, mesh, vidx) {
   console.log('highlighted voxel: ' + vidx)
 })
 
-highlight.on('remove', function(mesh, vidx) {
+highlighter.on('remove', function(mesh, vidx) {
   console.log('UN-highlighted voxel: ' + vidx)
 })
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,11 @@ function Highlighter(game, opts) {
   var size = this.game.cubeSize
   var geometry = this.opts.geometry || new this.game.THREE.CubeGeometry(size + 0.01, size + 0.01, size + 0.01)
   var material = this.opts.material || new this.game.THREE.MeshBasicMaterial({
-    color: new this.game.THREE.Color(0x000000),
+    color: 0x000000,
     wireframe: true,
-    wireframeLinewidth: this.opts.wireframeLinewidth || 3
+    wireframeLinewidth: this.opts.wireframeLinewidth || 3,
+    transparent: true, 
+    opacity: this.opts.wireframeOpacity || 0.5
   })
   this.cube = new this.game.THREE.Mesh(geometry, material)
   this.highlightActive = false

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type":"git",
-    "url": "git@github.com:maxogden/voxel-highlighter.git"
+    "url": "git@github.com:maxogden/voxel-highlight.git"
   },
   "dependencies": {
     "underscore": "1.4.3",


### PR DESCRIPTION
Thanks for accepting my previous request! This follow-up is just for a few loose ends.

Also a question: do you want to keep the voxel-engine requirement at 0.3.6 or bump to 0.6.0? If we bump, we can remove the extra getCameraPosition and getCameraVector legacy support functions.
