### PR TITLE
fixed raycast bug, removed legacy voxel-engine 0.3.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ highlight or manipulate with the voxel that the player is currently looking at
 npm install voxel-highlight
 ```
 
+or just add to the package.json file of your voxel-engine project
+
 ## example
 
 ```javascript
@@ -23,7 +25,7 @@ options can be:
 ```javascript
 {
   frequency: how often in milliseconds to highlight, default is 100
-  distance: how far in game distance things should be highlighted, default is 500
+  distance: how far in game distance things should be highlighted, default is 10
   geometry: threejs geometry to use for the highlight, default is a cubegeometry
   material: material to use with the geometry, default is a wireframe
   wireframeLinewidth: if using default material wireframe, default is 3
@@ -31,33 +33,17 @@ options can be:
 }
 ```
 
-### highlight.on('highlight', function(position, mesh, voxelIndex) {})
+### highlight.on('highlight', mesh, voxelIndex) {})
 
 gets called when highlighter highlights something
 
 ### highlight.on('remove', function(mesh, voxelIndex) {})
 
-gets called when highlighter unhighlights something. mesh also has a `.position`
+gets called when highlighter unhighlights something
 
 # Get the demo running on your machine
 
-The first time you set up, you should install the required npm packages:
-
-```
-cd voxel-highlight
-npm install
-npm install browserify -g
-```
-
-Then run the start script (which you'll need to do every time you want to run the demo):
-
-```
-npm start
-```
-
-Then point your browser to [http://localhost:8080](http://localhost:8080) and have fun!
-
-If you get stuck then look at the [readme for voxel-hello-world](http://github.com/maxogden/voxel-hello-world)
+look at [voxel-hello-world](http://github.com/maxogden/voxel-hello-world) for demo usage
 
 ## license
 

--- a/index.js
+++ b/index.js
@@ -48,14 +48,13 @@ Highlighter.prototype.highlight = function () {
     }
     return // no highlight, done with common case
   }
-  // select which voxel to highlight (within current chunk)
-  var voxelVector = this.game.voxels.voxelVector(hit)
-  var newVoxelIdx = this.game.voxels.voxelIndex(voxelVector)
+  // update position of highlight mesh if changed
+  hit.set(Math.floor(hit.x) + 0.5, Math.floor(hit.y) + 0.5, Math.floor(hit.z) + 0.5)
+  var newVoxelIdx = JSON.stringify(hit)
   if (newVoxelIdx === this.currVoxelIdx) {
     return // voxel already highlighted, done with common case
   }
-  // update position of highlight mesh (now assuming block size of 1)
-  this.mesh.position.set(Math.floor(hit.x) + 0.5, Math.floor(hit.y) + 0.5, Math.floor(hit.z) + 0.5)
+  this.mesh.position.copy(hit)
 
   if (this.currVoxelIdx) {
     this.emit('remove', this.mesh, this.currVoxelIdx) // moved highlight

--- a/index.js
+++ b/index.js
@@ -2,76 +2,81 @@ var inherits = require('inherits')
 var events = require('events')
 var _ = require('underscore')
 
-module.exports = function (game, opts) {
-  return new Highlighter(game, opts)
-}
+module.exports = Highlighter
 
 function Highlighter(game, opts) {
-  this.opts = opts || {}
+  if (!(this instanceof Highlighter)) {
+    console.log("constructor called without new keyword")
+    return new Highlighter(game, opts)
+  }
   this.game = game
-  this.prevVoxelIdx = 0
-  this.cameraPosition = new this.game.THREE.Vector3()
-  this.cameraVector = new this.game.THREE.Vector3()
-  var size = this.game.cubeSize
-  var geometry = this.opts.geometry || new this.game.THREE.CubeGeometry(size + 0.01, size + 0.01, size + 0.01)
-  var material = this.opts.material || new this.game.THREE.MeshBasicMaterial({
+  this.opts = opts || {}
+  this.currVoxelIdx // undefined when no voxel selected for highlight
+  this.cubeSize = game.cubeSize // + 0.01
+  var geometry = this.opts.geometry || new game.THREE.CubeGeometry(this.cubeSize, this.cubeSize, this.cubeSize)
+  var material = this.opts.material || new game.THREE.MeshBasicMaterial({
     color: 0x000000,
     wireframe: true,
     wireframeLinewidth: this.opts.wireframeLinewidth || 3,
-    transparent: true, 
+    transparent: true,
     opacity: this.opts.wireframeOpacity || 0.5
   })
-  this.cube = new this.game.THREE.Mesh(geometry, material)
-  this.highlightActive = false
-  this.game.on('tick', _.throttle(this.highlight.bind(this), this.opts.frequency || 100))
+  this.mesh = new game.THREE.Mesh(geometry, material)
+  this.stepSegment = new game.THREE.Vector3();
+  this.stepPosition = new game.THREE.Vector3();
+
+  game.on('tick', _.throttle(this.highlight.bind(this), this.opts.frequency || 100))
 }
 
 inherits(Highlighter, events.EventEmitter)
 
 Highlighter.prototype.highlight = function () {
-  var self = this
-  var removeHighlight = function () {
-    self.game.scene.remove(self.cube)
-    self.emit('remove', self.cube, self.prevVoxelIdx)
-    self.highlightActive = false
+  var hit
+  var stepDistance = 0.1
+  var distanceChecked = 0
+  var maxDistance = this.opts.distance || 10
+
+  this.stepPosition.copy(this.game.cameraPosition())
+  this.stepSegment.copy(this.game.cameraVector()).multiplyScalar(stepDistance)
+
+  while (distanceChecked < maxDistance && !hit) {
+    distanceChecked += stepDistance
+    this.stepPosition.addSelf(this.stepSegment)
+    if (this.game.voxels.voxelAtPosition(this.stepPosition)) {
+      hit = this.stepPosition
+    }
   }
-  var getCameraPosition = function () { // only for legacy voxel-engine 0.3.6 support
-    self.cameraPosition.multiplyScalar(0)
-    self.game.camera.matrixWorld.multiplyVector3(self.cameraPosition)
-    return self.cameraPosition
-  }
-  var getCameraVector = function () { // only for legacy voxel-engine 0.3.6 support
-    self.cameraVector.multiplyScalar(0)
-    self.cameraVector.z = -1
-    self.game.camera.matrixWorld.multiplyVector3(self.cameraVector)
-    self.cameraVector.subSelf(self.cameraPosition).normalize()
-    return self.cameraVector
-  }
-  var camPos = (this.game.cameraPosition && this.game.cameraPosition()) || getCameraPosition()
-  var camVec = (this.game.cameraVector && this.game.cameraVector()) || getCameraVector()
-  var hit = this.game.raycast(camPos, camVec, this.opts.distance || 500)
   if (!hit) {
-    if (this.highlightActive) removeHighlight()
-    return
+    if (this.currVoxelIdx) { // remove existing highlight
+      this.game.scene.remove(this.mesh)
+      this.emit('remove', this.mesh, this.currVoxelIdx)
+      this.currVoxelIdx = undefined // can't use 0 since there could be a voxel there
+    }
+    return // no highlight, done with common case
   }
+  // select a voxel to highlight
   var voxelVector = this.game.voxels.voxelVector(hit)
-  var voxelIdx = this.game.voxels.voxelIndex(voxelVector)
-  if (this.highlightActive) {
-    if (this.prevVoxelIdx === voxelIdx) return // no change
-    removeHighlight()
+  var newVoxelIdx = this.game.voxels.voxelIndex(voxelVector)
+  if (newVoxelIdx === this.currVoxelIdx) {
+    return // voxel already highlighted, done with common case
   }
-  this.prevVoxelIdx = voxelIdx
+  // update position of highlight mesh
   var chunk = this.game.voxels.chunkAtPosition(hit)
   var pos = this.game.voxels.getBounds(chunk[0], chunk[1], chunk[2])[0]
-  var size = this.game.cubeSize
-  pos[0] = pos[0] * size
-  pos[1] = pos[1] * size
-  pos[2] = pos[2] * size
-  pos[0] += voxelVector.x * size
-  pos[1] += voxelVector.y * size
-  pos[2] += voxelVector.z * size
-  this.cube.position.set(pos[0] + size / 2, pos[1] + size / 2, pos[2] + size / 2)
-  this.game.scene.add(this.cube)
-  this.highlightActive = true
-  this.emit('highlight', pos, this.cube, voxelIdx)
+  pos[0] = pos[0] * this.cubeSize
+  pos[1] = pos[1] * this.cubeSize
+  pos[2] = pos[2] * this.cubeSize
+  pos[0] += voxelVector.x * this.cubeSize
+  pos[1] += voxelVector.y * this.cubeSize
+  pos[2] += voxelVector.z * this.cubeSize
+  this.mesh.position.set(pos[0] + this.cubeSize / 2, pos[1] + this.cubeSize / 2, pos[2] + this.cubeSize / 2)
+
+  if (this.currVoxelIdx) {
+    this.emit('remove', this.mesh, this.currVoxelIdx) // moved highlight
+  }
+  else {
+    this.game.scene.add(this.mesh) // fresh highlight
+  }
+  this.emit('highlight', this.mesh, newVoxelIdx)
+  this.currVoxelIdx = newVoxelIdx
 }


### PR DESCRIPTION
Now using simplified raycast approach instead of Game.prototype.raycast:

```
  // cheap raycast "lite":
  var stepDistance = 0.1
  var distanceChecked = 0
  var maxDistance = this.opts.distance || 10
  this.stepPosition.copy(this.game.cameraPosition())
  this.stepSegment.copy(this.game.cameraVector()).multiplyScalar(stepDistance)
  while (distanceChecked < maxDistance && !hit) {
    distanceChecked += stepDistance
    this.stepPosition.addSelf(this.stepSegment)
    if (this.game.voxels.voxelAtPosition(this.stepPosition)) {
      var hit = this.stepPosition
    }
  }
```

Also, using voxel size of 1 when calculating positions
