### PR TITLE
Now using voxel-engine 0.14.0 with animated adjacent highlight transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ options can be:
   wireframeLinewidth: if using default material wireframe, default is 3
   wireframeOpacity: if using default material wireframe, default is 0.5
   color: highlight cube color, default is 0x000000
+  adjacentAnimate: animate movement of highlight cube to/from adjacent position
+  adjacentActive: function to toggle adjacent highlight, default is { return game.controls.state.alt }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,44 @@ function Highlighter(game, opts) {
     opacity: opts.wireframeOpacity || 0.5
   })
   this.mesh = new game.THREE.Mesh(geometry, material)
-  this.meshAdj = new game.THREE.Mesh(geometry, material)
   this.distance = opts.distance || 10
-  game.on('tick', _.throttle(this.highlight.bind(this), opts.frequency || 100))
   this.currVoxelPos // undefined when no voxel selected for highlight
   this.currVoxelAdj // undefined when no adjacent voxel selected for highlight
+  this.adjacentAnimate = opts.adjacentAnimate
+  // the adjacent highlight will be active when the following returns true
+  // default: 'alt' control mapped in game.controls (e.g. hold <Ctrl> key)
+  this.adjacentActive = opts.adjacentActive || function () { return game.controls.state.alt }
+
+  // highlight cube 'easing' animation, called every tick if enabled
+  var self = this
+  if (opts.adjacentAnimate) game.on('tick', function (dt) {
+    var target
+    var rate
+    if (self.currVoxelAdj) { // animate cube from existing anchor voxel to empty adjacent position
+      target = [self.currVoxelAdj[0] + 0.5, self.currVoxelAdj[1] + 0.5, self.currVoxelAdj[2] + 0.5]
+      rate = 15
+    }
+    else if (self.currVoxelPos) { // animate cube from empty adjacent position back to anchor voxel
+      target = [self.currVoxelPos[0] + 0.5, self.currVoxelPos[1] + 0.5, self.currVoxelPos[2] + 0.5]
+      rate = 30
+    }
+    else {
+      return
+    }
+    var pos = self.mesh.position
+    if (Math.abs(target[0] - pos.x) < .1
+     && Math.abs(target[1] - pos.y) < .1
+     && Math.abs(target[2] - pos.z) < .1) {
+      pos.set(target[0], target[1], target[2])
+      return // close enough to snap and be done
+    }
+    dt = dt / 1000 // usually around .016 seconds (60 FPS)
+    pos.x += rate * dt * (target[0] - pos.x)
+    pos.y += rate * dt * (target[1] - pos.y)
+    pos.z += rate * dt * (target[2] - pos.z)
+  })
+
+  game.on('tick', _.throttle(this.highlight.bind(this), opts.frequency || 100))
 }
 
 inherits(Highlighter, events.EventEmitter)
@@ -32,67 +65,74 @@ Highlighter.prototype.highlight = function () {
   var cv = this.game.cameraVector()
   var hit = this.game.raycastVoxels(cp, cv, this.distance)
 
-  var removeHighlight = function (self) { // remove highlight if any
-    if (self) { // remove existing highlight
-      self.game.scene.remove(self.mesh)
-      self.emit('remove', self.currVoxelPos)
-      self.currVoxelPos = undefined
-    }
-  }
-
   var removeAdjacent = function (self) { // remove adjacent highlight if any
-    if (self.currVoxelAdj) {
-      self.game.scene.remove(self.meshAdj)
-      self.emit('remove-adjacent', self.currVoxelAdj)
-      self.currVoxelAdj = undefined
-    }
+    if (!self.currVoxelAdj) return
+    self.emit('remove-adjacent', self.currVoxelAdj.slice())
+    self.currVoxelAdj = undefined
   }
 
+  // remove existing highlight if any
   if (!hit) {
-    removeHighlight(this)
+    if (!this.currVoxelPos) return // already removed
+    this.game.scene.remove(this.mesh)
+    this.emit('remove', this.currVoxelPos.slice())
+    this.currVoxelPos = undefined
     removeAdjacent(this)
     return
   }
 
   // highlight hit block
-  var newVoxelPos = this.game.blockPosition(hit.position)
-  if (!this.currVoxelPos || newVoxelPos[0] !== this.currVoxelPos[0] || newVoxelPos[1] !== this.currVoxelPos[1] || newVoxelPos[2] !== this.currVoxelPos[2]) { // none or moved
+  var newVoxelPos = hit.voxel
+  if (!this.currVoxelPos
+    || newVoxelPos[0] !== this.currVoxelPos[0]
+    || newVoxelPos[1] !== this.currVoxelPos[1]
+    || newVoxelPos[2] !== this.currVoxelPos[2]) { // no current highlight or it moved
 
+    // move instantly
     this.mesh.position.set(newVoxelPos[0] + 0.5, newVoxelPos[1] + 0.5, newVoxelPos[2] + 0.5)
 
     if (this.currVoxelPos) {
-      this.emit('remove', this.currVoxelPos) // moved highlight
+      this.emit('remove', this.currVoxelPos.slice()) // moved highlight
     }
     else {
       this.game.scene.add(this.mesh) // fresh highlight
     }
-    this.emit('highlight', newVoxelPos)
+    this.emit('highlight', newVoxelPos.slice())
     this.currVoxelPos = newVoxelPos
+
+    removeAdjacent(this)
   }
 
-  // highlight block adjacent to hit (block placement preview) if enabled
-  if (!game.controls.state.alt && !game.controls.state.firealt) { // control key
+  // if in "place block" mode, highlight adjacent voxel instead
+  if (!this.adjacentActive()) {
     removeAdjacent(this)
+    // snap back if not animating
+    if (!this.adjacentAnimate) this.mesh.position.set(newVoxelPos[0] + 0.5, newVoxelPos[1] + 0.5, newVoxelPos[2] + 0.5)
     return
   }
-  var newVoxelAdj = this.game.blockPosition(hit.adjacent)
-  if (!this.currVoxelAdj || newVoxelAdj[0] !== this.currVoxelAdj[0] || newVoxelAdj[1] !== this.currVoxelAdj[1] || newVoxelAdj[2] !== this.currVoxelAdj[2]) { // no highlight or it moved
 
-    // raycast bug: adjacent above sometimes skips a block
-    if (newVoxelAdj[1] - newVoxelPos[1] > 1) {
-      console.log("adjacent highlight is elevated")
-      newVoxelAdj[1]--
-    }
+  // since we got here, we know we have a selected non-empty voxel
+  // and with an empty adjacent voxel that we can work with
+  var newVoxelAdj = hit.adjacent
+  if (!this.currVoxelAdj
+    || newVoxelAdj[0] !== this.currVoxelAdj[0]
+    || newVoxelAdj[1] !== this.currVoxelAdj[1]
+    || newVoxelAdj[2] !== this.currVoxelAdj[2]) { // no current adj highlight or it has moved
 
-    this.meshAdj.position.set(newVoxelAdj[0] + 0.5, newVoxelAdj[1] + 0.5, newVoxelAdj[2] + 0.5)
-
-    if (this.currVoxelAdj) {
-      this.emit('remove-adjacent', this.currVoxelAdj) // moved adjacent highlight
+    if (this.adjacentAnimate) {
+      // start at anchor block position, then ease to adjacent on async updates
+      this.mesh.position.set(newVoxelPos[0] + 0.5, newVoxelPos[1] + 0.5, newVoxelPos[2] + 0.5)
     }
     else {
-      this.game.scene.add(this.meshAdj) // fresh highlight
+      // instant snap, no easing enabled
+      this.mesh.position.set(newVoxelAdj[0] + 0.5, newVoxelAdj[1] + 0.5, newVoxelAdj[2] + 0.5)
     }
-    this.emit('highlight-adjacent', newVoxelAdj)
+
+    if (this.currVoxelAdj) {
+      this.emit('remove-adjacent', this.currVoxelAdj.slice()) // moved adjacent highlight
+    }
+
+    this.emit('highlight-adjacent', newVoxelAdj.slice())
     this.currVoxelAdj = newVoxelAdj
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-highlight",
   "description": "highlight or manipulate the voxel the player is looking at",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type":"git",
     "url": "git@github.com:maxogden/voxel-highlight.git"
@@ -11,6 +11,6 @@
     "inherits": "1.0.0"
   },
   "peerDependencies": {
-    "voxel-engine": ">=0.10.0"
+    "voxel-engine": ">=0.14.0"
   }
 }


### PR DESCRIPTION
I hope you don't mind me going a little crazy with this thing...

Updated to use voxel-engine 0.14.0 raycast results API (e.g. hit.voxel and hit.adjacent int arrays)

Also, when switching highlight from existing voxel to empty adjacent space (e.g. by pressing control key), the cube movement is slightly animated (only if opts.adjacentAnimate is true). A side benefit of this is that we are back to using a single mesh.

demo voxel-hello-world pull request to follow! thanks
