### PR TITLE
0.0.9 - added voxel multi-select, configurable animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ var Highlight = require('voxel-highlight')
 var highlighter = new Highlight(game)
 ```
 
+## api and usage
+
 ### highlight(gameInstance, optionalOptions)
 
 options can be:
@@ -37,10 +39,32 @@ options can be:
   wireframeLinewidth: if using default material wireframe, default is 3
   wireframeOpacity: if using default material wireframe, default is 0.5
   color: highlight cube color, default is 0x000000
-  adjacentAnimate: animate movement of highlight cube to/from adjacent position
+  animate: animate movement of highlight cuboid, default is false
   adjacentActive: function to toggle adjacent highlight, default is { return game.controls.state.alt }
+  selectActive: function to toggle adjacent highlight, default is { return game.controls.state.select }
+  animateFunction: function to ease position changes, see default below
 }
 ```
+
+Default animation function:
+```javascript
+  opts.animateFunction = function (position, targetPosition, deltaTime) {
+    if (!position || !targetPosition || !deltaTime) return;
+    var rate = 10 // speed in voxels per second
+    if (Math.abs(targetPosition[0] - position.x) < 0.05
+     && Math.abs(targetPosition[1] - position.y) < 0.05
+     && Math.abs(targetPosition[2] - position.z) < 0.05) {
+      position.set(targetPosition[0], targetPosition[1], targetPosition[2])
+      return; // close enough to snap and be done
+    }
+    deltaTime = deltaTime / 1000 // usually around .016 seconds (60 FPS)
+    position.x += rate * deltaTime * (targetPosition[0] - position.x)
+    position.y += rate * deltaTime * (targetPosition[1] - position.y)
+    position.z += rate * deltaTime * (targetPosition[2] - position.z)
+  }
+```
+
+## events
 
 ### highlighter.on('highlight', function(voxelPosArray) {})
 
@@ -57,6 +81,14 @@ called when an adjacent voxel is highlighted
 ### highlighter.on('remove-adjacent', function(voxelPosArray) {})
 
 called when an adjacent voxel is un-highlighted
+
+### highlighter.on('highlight-select', funnction(selectionBounds) {}
+
+called when a selection of more than one voxel is highlighted. selectionBounds has .start and .end position arrays
+
+### highlighter.on('highlight-deselect', funnction(selectionBounds) {}
+
+called when a selection of more than one voxel is no longer highlighted. selectionBounds has .start and .end position arrays
 
 # Get the demo running on your machine
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function Highlighter(game, opts) {
   if (!(this instanceof Highlighter)) return new Highlighter(game, opts)
   this.game = game
   opts = opts || {}
-  var geometry = opts.geometry || new game.THREE.CubeGeometry(1, 1, 1)
+  var geometry = this.geometry = opts.geometry || new game.THREE.CubeGeometry(1, 1, 1)
   var material = opts.material || new game.THREE.MeshBasicMaterial({
     color: opts.color || 0x000000,
     wireframe: true,
@@ -20,41 +20,44 @@ function Highlighter(game, opts) {
   this.distance = opts.distance || 10
   this.currVoxelPos // undefined when no voxel selected for highlight
   this.currVoxelAdj // undefined when no adjacent voxel selected for highlight
-  this.adjacentAnimate = opts.adjacentAnimate
+  this.targetPosition // desired position of highlight cube center
+  
   // the adjacent highlight will be active when the following returns true
-  // default: 'alt' control mapped in game.controls (e.g. hold <Ctrl> key)
   this.adjacentActive = opts.adjacentActive || function () { return game.controls.state.alt }
+  
+  // the selection highlight will be active when the following returns true
+  this.selectActive = opts.selectActive || function () { return game.controls.state.select }
+  
+  // animate highlight transitions?
+  this.animate = opts.animate
+  this.animateFunction = opts.animateFunction || function (position, targetPosition, deltaTime) {
+    if (!position || !targetPosition || !deltaTime) return;
+    var rate = 10
+    if (Math.abs(targetPosition[0] - position[0]) < 0.05
+     && Math.abs(targetPosition[1] - position[1]) < 0.05
+     && Math.abs(targetPosition[2] - position[2]) < 0.05) {
+      return targetPosition // close enough to snap and be done
+    }
+    deltaTime = deltaTime / 1000 // usually around .016 seconds (60 FPS)
+    position[0] += rate * deltaTime * (targetPosition[0] - position[0])
+    position[1] += rate * deltaTime * (targetPosition[1] - position[1])
+    position[2] += rate * deltaTime * (targetPosition[2] - position[2])
+    return position
+  }
 
-  // highlight cube 'easing' animation, called every tick if enabled
+  // highlight 'easing' animation, called every tick if enabled
   var self = this
-  if (opts.adjacentAnimate) game.on('tick', function (dt) {
-    var target
-    var rate
-    if (self.currVoxelAdj) { // animate cube from existing anchor voxel to empty adjacent position
-      target = [self.currVoxelAdj[0] + 0.5, self.currVoxelAdj[1] + 0.5, self.currVoxelAdj[2] + 0.5]
-      rate = 15
-    }
-    else if (self.currVoxelPos) { // animate cube from empty adjacent position back to anchor voxel
-      target = [self.currVoxelPos[0] + 0.5, self.currVoxelPos[1] + 0.5, self.currVoxelPos[2] + 0.5]
-      rate = 30
-    }
-    else {
-      return
-    }
-    var pos = self.mesh.position
-    if (Math.abs(target[0] - pos.x) < .1
-     && Math.abs(target[1] - pos.y) < .1
-     && Math.abs(target[2] - pos.z) < .1) {
-      pos.set(target[0], target[1], target[2])
-      return // close enough to snap and be done
-    }
-    dt = dt / 1000 // usually around .016 seconds (60 FPS)
-    pos.x += rate * dt * (target[0] - pos.x)
-    pos.y += rate * dt * (target[1] - pos.y)
-    pos.z += rate * dt * (target[2] - pos.z)
+  if (this.animate) game.on('tick', function (dt) {
+    var position = [self.mesh.position.x, self.mesh.position.y, self.mesh.position.z]
+    position = self.animateFunction(position, self.targetPosition, dt)
+    if (position) self.mesh.position.set(position[0], position[1], position[2])
   })
 
   game.on('tick', _.throttle(this.highlight.bind(this), opts.frequency || 100))
+  
+  // anchors for multi-voxel selection
+  this.selectStart
+  this.selectEnd
 }
 
 inherits(Highlighter, events.EventEmitter)
@@ -64,32 +67,28 @@ Highlighter.prototype.highlight = function () {
   var cp = this.game.cameraPosition()
   var cv = this.game.cameraVector()
   var hit = this.game.raycastVoxels(cp, cv, this.distance)
+  var targetPositionCandidate
 
   var removeAdjacent = function (self) { // remove adjacent highlight if any
-    if (!self.currVoxelAdj) return
-    self.emit('remove-adjacent', self.currVoxelAdj.slice())
+    if (!self.currVoxelAdj) return;
+    self.emit('remove-adjacent', self.currVoxelAdj)
     self.currVoxelAdj = undefined
   }
 
   // remove existing highlight if any
   if (!hit) {
-    if (!this.currVoxelPos) return // already removed
+    if (!this.currVoxelPos) return; // already removed
     this.game.scene.remove(this.mesh)
     this.emit('remove', this.currVoxelPos.slice())
     this.currVoxelPos = undefined
     removeAdjacent(this)
-    return
   }
 
-  // highlight hit block
   var newVoxelPos = hit.voxel
   if (!this.currVoxelPos
     || newVoxelPos[0] !== this.currVoxelPos[0]
     || newVoxelPos[1] !== this.currVoxelPos[1]
     || newVoxelPos[2] !== this.currVoxelPos[2]) { // no current highlight or it moved
-
-    // move instantly
-    this.mesh.position.set(newVoxelPos[0] + 0.5, newVoxelPos[1] + 0.5, newVoxelPos[2] + 0.5)
 
     if (this.currVoxelPos) {
       this.emit('remove', this.currVoxelPos.slice()) // moved highlight
@@ -98,41 +97,68 @@ Highlighter.prototype.highlight = function () {
       this.game.scene.add(this.mesh) // fresh highlight
     }
     this.emit('highlight', newVoxelPos.slice())
-    this.currVoxelPos = newVoxelPos
-
-    removeAdjacent(this)
+    this.currVoxelPos = newVoxelPos.slice()
   }
+  // try to set the position every time, it may be overridden below
+  targetPositionCandidate = [this.currVoxelPos[0] + 0.5, this.currVoxelPos[1] + 0.5, this.currVoxelPos[2] + 0.5]
 
-  // if in "place block" mode, highlight adjacent voxel instead
-  if (!this.adjacentActive()) {
-    removeAdjacent(this)
-    // snap back if not animating
-    if (!this.adjacentAnimate) this.mesh.position.set(newVoxelPos[0] + 0.5, newVoxelPos[1] + 0.5, newVoxelPos[2] + 0.5)
-    return
+  // if in "adjacent" mode, highlight adjacent voxel instead
+  if (this.adjacentActive()) {
+    // since we got here, we know we have a selected non-empty voxel
+    // and with an empty adjacent voxel that we can work with
+    var newVoxelAdj = hit.adjacent
+    if (!this.currVoxelAdj
+      || newVoxelAdj[0] !== this.currVoxelAdj[0]
+      || newVoxelAdj[1] !== this.currVoxelAdj[1]
+      || newVoxelAdj[2] !== this.currVoxelAdj[2]) { // no current adj highlight or it has moved
+  
+      if (this.currVoxelAdj) {
+        this.emit('remove-adjacent', this.currVoxelAdj.slice()) // moved adjacent highlight
+      }
+      this.emit('highlight-adjacent', newVoxelAdj.slice())
+      
+      this.currVoxelAdj = newVoxelAdj.slice()
+    }
+    targetPositionCandidate = [this.currVoxelAdj[0] + 0.5, this.currVoxelAdj[1] + 0.5, this.currVoxelAdj[2] + 0.5]
   }
+  else removeAdjacent(this)
 
-  // since we got here, we know we have a selected non-empty voxel
-  // and with an empty adjacent voxel that we can work with
-  var newVoxelAdj = hit.adjacent
-  if (!this.currVoxelAdj
-    || newVoxelAdj[0] !== this.currVoxelAdj[0]
-    || newVoxelAdj[1] !== this.currVoxelAdj[1]
-    || newVoxelAdj[2] !== this.currVoxelAdj[2]) { // no current adj highlight or it has moved
-
-    if (this.adjacentAnimate) {
-      // start at anchor block position, then ease to adjacent on async updates
-      this.mesh.position.set(newVoxelPos[0] + 0.5, newVoxelPos[1] + 0.5, newVoxelPos[2] + 0.5)
+  // if in "select" mode, track start and end voxel bounds
+  if (this.selectActive()) {
+    if (!this.selectStart) { // start a new selection
+      this.selectStart = this.selectEnd = this.currVoxelAdj || this.currVoxelPos
     }
     else {
-      // instant snap, no easing enabled
-      this.mesh.position.set(newVoxelAdj[0] + 0.5, newVoxelAdj[1] + 0.5, newVoxelAdj[2] + 0.5)
+      var endCandidate = this.currVoxelAdj || this.currVoxelPos
+      if (endCandidate[0] !== this.selectEnd[0]
+       || endCandidate[1] !== this.selectEnd[1]
+       || endCandidate[2] !== this.selectEnd[2]) { 
+         
+        this.selectEnd = endCandidate // selection end has changed
+        
+        this.emit('highlight-select', { start: this.selectStart.slice(), end: this.selectEnd.slice() })
+        
+        var scale = []
+        scale[0] = Math.abs(this.selectEnd[0] - this.selectStart[0]) + 1
+        scale[1] = Math.abs(this.selectEnd[1] - this.selectStart[1]) + 1
+        scale[2] = Math.abs(this.selectEnd[2] - this.selectStart[2]) + 1
+        this.mesh.scale.set(scale[0], scale[1], scale[2])
+        
+        var pos = []
+        pos[0] = this.selectStart[0] + 0.5 + (this.selectEnd[0] - this.selectStart[0]) / 2
+        pos[1] = this.selectStart[1] + 0.5 + (this.selectEnd[1] - this.selectStart[1]) / 2
+        pos[2] = this.selectStart[2] + 0.5 + (this.selectEnd[2] - this.selectStart[2]) / 2
+        this.targetPosition = pos
+      }
     }
-
-    if (this.currVoxelAdj) {
-      this.emit('remove-adjacent', this.currVoxelAdj.slice()) // moved adjacent highlight
-    }
-
-    this.emit('highlight-adjacent', newVoxelAdj.slice())
-    this.currVoxelAdj = newVoxelAdj
   }
+  else {
+    if (this.selectStart) {
+      this.emit('highlight-deselect', { start: this.selectStart.slice(), end: this.selectEnd.slice() })
+      this.selectStart = null
+      this.mesh.scale.set(1, 1, 1)
+    }
+    this.targetPosition = targetPositionCandidate // highlighted voxel or adjacent
+  }
+  if (!this.animate) this.mesh.position.set(this.targetPosition[0], this.targetPosition[1], this.targetPosition[2])
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "voxel-highlight",
   "description": "highlight or manipulate the voxel the player is looking at",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type":"git",
     "url": "git@github.com:maxogden/voxel-highlight.git"
   },
   "dependencies": {
-    "underscore": "1.4.3",
+    "underscore": "1.4.4",
     "inherits": "1.0.0"
   },
   "peerDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,44 @@
+var opts = {
+  highlightOpts: {
+    color: 0xffff00,
+    distance: 100,
+    animate: false
+  },
+  generate: function (x, y, z) {
+    return y % 16 ? 0 : Math.ceil(Math.random() * 2) 
+  },
+  keybindings: {
+      'W': 'forward'
+    , 'A': 'left'
+    , 'S': 'backward'
+    , 'D': 'right'
+    , '<mouse 1>': 'fire'
+    , '<mouse 2>': 'firealt'
+    , '<space>': 'jump'
+    , '<shift>': 'crouch'
+    , '<control>': 'alt'
+    , 'K': 'select'
+  }
+}
+
+var game = require('voxel-hello-world')(opts)
+
+var highlighter = game.highlighter
+highlighter.on('highlight', function (voxelPos) {
+  console.log(">   [" + voxelPos + "] highlighted voxel")
+})
+highlighter.on('remove', function (voxelPos) {
+  console.log("<   [" + voxelPos + "] removed voxel highlight")
+})
+highlighter.on('highlight-adjacent', function (voxelPos) {
+  console.log(">>  [" + voxelPos + "] highlighted adjacent")
+})
+highlighter.on('remove-adjacent', function (voxelPos) {
+  console.log("<<  [" + voxelPos + "] removed adjacent highlight")
+})
+highlighter.on('highlight-select', function (selection) {
+  console.log(">>> [" + selection.start + "][" + selection.end + "] highlighted selection")
+})
+highlighter.on('highlight-deselect', function (selection) {
+  console.log("<<< [" + selection.start + "][" + selection.end + "] selection un-highlighted")
+})


### PR DESCRIPTION
The player can now select a block of voxels by holding the 'select' key and highlighting from some start voxel (or adjacent) to an end voxel (or adjacent).

The select start and end position arrays are emitted with 2 new events:
1. 'highlight-select' (whenever the ending voxel changes)
2. 'highlight-deselect' (when the select key is released)

The voxel multi-block selection is not used for anything yet, but I am thinking of copy-paste functionality or cookie-cutter building perhaps. More demo stuff could be added to test.js, which uses voxel-hello-world (or soon will) and adds the 'K' key binding for the 'select' function.

Also, the simple animation of highlight position changes can now be specified by passing in an easing function. The default function is very simple. I think I may prefer not using the animation at all.
